### PR TITLE
Add docs on running the LSP JAR from the terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,18 @@ The Language Server for JavaCC21 supports:
  * definition for identifier
  * highlight for identifiers
 
- See the following demo:
+See the following demo:
  
- ![JavaCC21 demo](images/JavaCC21Demo.gif)
+![JavaCC21 demo](images/JavaCC21Demo.gif)
+
+## Run
+
+To run the language server, download the compiled JAR [from here](https://github.com/angelozerr/javacc21-ls/raw/main/com.javacc.lsp4e/server/com.javacc.ls-uber.jar).
+
+Then, use the following command:
+
+```sh
+java -jar com.javacc.ls-uber.jar
+```
+
+Language server protocol messages are passed using standard I/O.


### PR DESCRIPTION
I came across this project earlier today as I was looking for an LSP server for JavaCC - thanks for developing it!

I don't use Eclipse or VSCode, so I was looking for a way to run the server separately. It took me a while to notice there's a compiled JAR for the language server in the Eclipse plugin folder.

I've updated the README with instructions on running it from the terminal, in case others have a similar issue. 